### PR TITLE
[Rft] zk client

### DIFF
--- a/database/kv/zk/client_test.go
+++ b/database/kv/zk/client_test.go
@@ -146,7 +146,7 @@ func TestCreate(t *testing.T) {
 		_ = ts.Stop()
 		assert.Nil(t, err)
 	}()
-	err = z.Create("test1/test2/test3/test4")
+	err = z.Create("/test1/test2/test3/test4")
 	assert.NoError(t, err)
 
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}


### PR DESCRIPTION
1. ignore the zk.ErrNodeExists error
2. ignore the ErrNilChildren error
3. CreateWithValue will also create parent nodes with the value

<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```