### PR TITLE
fix: ZapConfig OutputPaths default set stdout

### DIFF
--- a/log/logger/file_log.yml
+++ b/log/logger/file_log.yml
@@ -30,7 +30,7 @@ zapConfig:
     nameEncoder: ""
 
   outputPaths:
-    - "stderr"
+    - "stdout"
   errorOutputPaths:
     - "stderr"
   initialFields:

--- a/log/logger/logger.go
+++ b/log/logger/logger.go
@@ -81,7 +81,7 @@ func InitLogger(conf *Config) {
 			Development:      false,
 			Encoding:         "console",
 			EncoderConfig:    zapLoggerEncoderConfig,
-			OutputPaths:      []string{"stderr"},
+			OutputPaths:      []string{"stdout"},
 			ErrorOutputPaths: []string{"stderr"},
 		}
 	} else {


### PR DESCRIPTION
**What this PR does**:
ZapConfig OutputPaths default set stdout

**Which issue(s) this PR fixes**:
Fixes issue: https://github.com/apache/dubbo-go/issues/2148  
