### PR TITLE
refactor: remove grpc.WithBlock() from etcd client

### DIFF
--- a/database/kv/etcd/v3/client.go
+++ b/database/kv/etcd/v3/client.go
@@ -29,7 +29,6 @@ import (
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
-	"google.golang.org/grpc"
 )
 
 var (
@@ -103,11 +102,10 @@ func NewClient(name string, endpoints []string, timeout time.Duration, heartbeat
 		Context:     ctx,
 		Endpoints:   endpoints,
 		DialTimeout: timeout,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 	})
 	if err != nil {
 		cancel()
-		return nil, perrors.WithMessage(err, "new raw client block connect to server")
+		return nil, perrors.WithMessage(err, "new raw client connect to server")
 	}
 
 	c := &Client{
@@ -141,11 +139,10 @@ func NewClientWithOptions(ctx context.Context, opts *Options) (*Client, error) {
 		TLS:         opts.TLS,
 		Username:    opts.Username,
 		Password:    opts.Password,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 	})
 	if err != nil {
 		cancel()
-		return nil, perrors.WithMessage(err, "new raw client block connect to server")
+		return nil, perrors.WithMessage(err, "new raw client connect to server")
 	}
 
 	c := &Client{


### PR DESCRIPTION
**What this PR does**:
This PR removes the deprecated `grpc.WithBlock()` option from the etcd client implementation in both `NewClient` and `NewClientWithOptions` functions. This change follows gRPC best practices and improves application startup performance by making connections establish asynchronously in the background instead of blocking during client creation.

**Which issue(s) this PR fixes**:
Fixes #130

**Special notes for your reviewer**:
- All existing tests pass, ensuring backward compatibility
- The connection will now be established asynchronously in the background
- This change addresses the gRPC anti-pattern mentioned in the official documentation
- The etcd client will still work correctly as connections are managed internally with automatic retry and reconnection mechanisms
- No API changes - this is purely an internal optimization

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```