### PR TITLE
Revert etcd client to previous state without grpc.WithBlock()

### DIFF
--- a/database/kv/etcd/v3/client.go
+++ b/database/kv/etcd/v3/client.go
@@ -27,8 +27,6 @@ import (
 	"time"
 
 	perrors "github.com/pkg/errors"
-	"google.golang.org/grpc"
-
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 )
@@ -104,7 +102,6 @@ func NewClient(name string, endpoints []string, timeout time.Duration, heartbeat
 		Context:     ctx,
 		Endpoints:   endpoints,
 		DialTimeout: timeout,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 	})
 	if err != nil {
 		cancel()
@@ -142,7 +139,6 @@ func NewClientWithOptions(ctx context.Context, opts *Options) (*Client, error) {
 		TLS:         opts.TLS,
 		Username:    opts.Username,
 		Password:    opts.Password,
-		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 	})
 	if err != nil {
 		cancel()


### PR DESCRIPTION
Description
Revert the changes from PR #134 to restore the state from PR #131 by removing grpc.WithBlock() from the etcd v3 client.

This restores asynchronous connection establishment, improving application startup performance and aligning with gRPC best practices.

Fixes apache/dubbo-go#3243

Approach
Remove google.golang.org/grpc import from database/kv/etcd/v3/client.go.

Remove DialOptions with grpc.WithBlock() from NewClient function.

Remove DialOptions with grpc.WithBlock() from NewClientWithOptions function.

Connection establishment is now asynchronous, allowing faster application startup while relying on etcd's built-in connection management and automatic reconnection mechanisms.

Applications that need to ensure connection readiness can implement their own health check logic after client initialization using the Valid() method.

Checklist
- [x] I confirm the target branch is develop
- [x] Code has passed local testing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed external gRPC dependency and simplified client initialization configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->