### PR TITLE
Fix: zk test cluster compat

### DIFF
--- a/database/kv/zk/client.go
+++ b/database/kv/zk/client.go
@@ -224,7 +224,7 @@ func (d *DefaultHandler) HandleZkEvent(z *ZookeeperClient) {
 		switch event.State {
 		case zk.StateDisconnected:
 			atomic.StoreUint32(&z.valid, 0)
-		case zk.StateConnected:
+		case zk.StateConnected, zk.StateSyncConnected:
 			z.eventRegistryLock.RLock()
 			for path, a := range z.eventRegistry {
 				if strings.HasPrefix(event.Path, path) {

--- a/database/kv/zk/client.go
+++ b/database/kv/zk/client.go
@@ -163,18 +163,19 @@ func (z *ZookeeperClient) createZookeeperConn() error {
 }
 
 // WithTestCluster sets test cluster for zk Client
-func WithTestCluster(ts *zk.TestCluster) Option {
+func WithTestCluster(ts *TestCluster) Option {
 	return func(opt *options) {
 		opt.Ts = ts
 	}
 }
 
 // NewMockZookeeperClient returns a mock Client instance
-func NewMockZookeeperClient(name string, timeout time.Duration, opts ...Option) (*zk.TestCluster, *ZookeeperClient, <-chan zk.Event, error) {
+func NewMockZookeeperClient(name string, timeout time.Duration, opts ...Option) (*TestCluster, *ZookeeperClient, <-chan zk.Event, error) {
 	var (
-		err error
-		z   *ZookeeperClient
-		ts  *zk.TestCluster
+		err         error
+		z           *ZookeeperClient
+		ts          *TestCluster
+		ownsCluster bool
 	)
 
 	z = &ZookeeperClient{
@@ -197,14 +198,18 @@ func NewMockZookeeperClient(name string, timeout time.Duration, opts ...Option) 
 	if option.Ts != nil {
 		ts = option.Ts
 	} else {
-		ts, err = zk.StartTestCluster(1, nil, nil, zk.WithRetryTimes(40))
+		ts, err = StartTestCluster(1, nil, nil, WithRetryTimes(40))
 		if err != nil {
 			return nil, nil, nil, perrors.WithMessagef(err, "zk.StartTestCluster fail")
 		}
+		ownsCluster = true
 	}
 
 	z.Conn, z.Session, err = ts.ConnectWithOptions(timeout)
 	if err != nil {
+		if ownsCluster {
+			_ = ts.Stop()
+		}
 		return nil, nil, nil, perrors.WithMessagef(err, "zk.Connect fail")
 	}
 	atomic.StoreUint32(&z.valid, 1)

--- a/database/kv/zk/client_test.go
+++ b/database/kv/zk/client_test.go
@@ -50,9 +50,9 @@ func verifyEventStateOrder(t *testing.T, c <-chan zk.Event, expectedStates []zk.
 
 func Test_getZookeeperClient(t *testing.T) {
 	var err error
-	var tc *zk.TestCluster
+	var tc *TestCluster
 	var address []string
-	tc, err = zk.StartTestCluster(1, nil, nil, zk.WithRetryTimes(40))
+	tc, err = StartTestCluster(1, nil, nil, WithRetryTimes(40))
 	assert.NoError(t, err)
 	assert.NotNil(t, tc.Servers[0])
 
@@ -83,9 +83,9 @@ func Test_getZookeeperClient(t *testing.T) {
 
 func Test_Close(t *testing.T) {
 	var err error
-	var tc *zk.TestCluster
+	var tc *TestCluster
 	var address []string
-	tc, err = zk.StartTestCluster(1, nil, nil, zk.WithRetryTimes(40))
+	tc, err = StartTestCluster(1, nil, nil, WithRetryTimes(40))
 	assert.NoError(t, err)
 	assert.NotNil(t, tc.Servers[0])
 	address = append(address, "127.0.0.1:"+strconv.Itoa(tc.Servers[0].Port))

--- a/database/kv/zk/options.go
+++ b/database/kv/zk/options.go
@@ -21,15 +21,11 @@ import (
 	"time"
 )
 
-import (
-	"github.com/dubbogo/go-zookeeper/zk"
-)
-
 // nolint
 type options struct {
 	ZkName string
 	Client *ZookeeperClient
-	Ts     *zk.TestCluster
+	Ts     *TestCluster
 }
 
 // Option will define a function of handling Options

--- a/database/kv/zk/server_help.go
+++ b/database/kv/zk/server_help.go
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Portions of this file are derived from github.com/dubbogo/go-zookeeper.
+ *
+ * Copyright (c) 2013, Samuel Stauffer <samuel@descolada.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package gxzookeeper
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+import (
+	"github.com/dubbogo/go-zookeeper/zk"
+)
+
+// TestServer represents one server in a ZooKeeper test cluster.
+type TestServer struct {
+	Port int
+	Path string
+	Srv  *Server
+}
+
+// TestCluster represents a ZooKeeper test cluster.
+type TestCluster struct {
+	Path    string
+	Servers []TestServer
+}
+
+type testClusterOptions struct {
+	retryTimes int
+}
+
+type testClusterOption func(*testClusterOptions)
+
+// WithRetryTimes sets the number of health-check attempts when starting a test cluster.
+func WithRetryTimes(times int) testClusterOption {
+	return func(options *testClusterOptions) {
+		options.retryTimes = times
+	}
+}
+
+// StartTestCluster starts a ZooKeeper test cluster with the requested number of servers.
+func StartTestCluster(
+	size int,
+	stdout io.Writer,
+	stderr io.Writer,
+	opts ...testClusterOption,
+) (*TestCluster, error) {
+	tmpPath, err := os.MkdirTemp("", "gozk")
+	if err != nil {
+		return nil, err
+	}
+
+	success := false
+	startPort := int(rand.Int31n(6000) + 10000)
+	cluster := &TestCluster{Path: tmpPath}
+	defer func() {
+		if !success {
+			_ = cluster.Stop()
+		}
+	}()
+
+	options := &testClusterOptions{retryTimes: 10}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	for serverN := 0; serverN < size; serverN++ {
+		srvPath := filepath.Join(tmpPath, fmt.Sprintf("srv%d", serverN))
+		if err := os.Mkdir(srvPath, 0o700); err != nil {
+			return nil, err
+		}
+		port := startPort + serverN*3
+
+		// ZooKeeper treats backslashes as escapes in dataDir, so always write a slash-separated path.
+		dataDir := filepath.ToSlash(srvPath)
+		cfg := ServerConfig{
+			ClientPort: port,
+			DataDir:    dataDir,
+		}
+
+		for i := 0; i < size; i++ {
+			cfg.Servers = append(cfg.Servers, ServerConfigServer{
+				ID:                 i + 1,
+				Host:               "127.0.0.1",
+				PeerPort:           startPort + i*3 + 1,
+				LeaderElectionPort: startPort + i*3 + 2,
+			})
+		}
+
+		cfgPath := filepath.Join(srvPath, "zoo.cfg")
+		cfgFile, err := os.Create(cfgPath)
+		if err != nil {
+			return nil, err
+		}
+		if err = cfg.Marshall(cfgFile); err != nil {
+			_ = cfgFile.Close()
+			return nil, err
+		}
+		if err = cfgFile.Close(); err != nil {
+			return nil, err
+		}
+
+		myIDFile, err := os.Create(filepath.Join(srvPath, "myid"))
+		if err != nil {
+			return nil, err
+		}
+		if _, err = fmt.Fprintf(myIDFile, "%d\n", serverN+1); err != nil {
+			_ = myIDFile.Close()
+			return nil, err
+		}
+		if err = myIDFile.Close(); err != nil {
+			return nil, err
+		}
+
+		srv := &Server{
+			ConfigPath: cfgPath,
+			Stdout:     stdout,
+			Stderr:     stderr,
+		}
+		if err := srv.Start(); err != nil {
+			return nil, err
+		}
+		cluster.Servers = append(cluster.Servers, TestServer{
+			Path: srvPath,
+			Port: cfg.ClientPort,
+			Srv:  srv,
+		})
+	}
+
+	if err := cluster.waitForStart(options.retryTimes, time.Second); err != nil {
+		return nil, err
+	}
+	success = true
+	return cluster, nil
+}
+
+// Connect connects to a server in the test cluster.
+func (tc *TestCluster) Connect(index int) (*zk.Conn, error) {
+	conn, _, err := zk.Connect([]string{fmt.Sprintf("127.0.0.1:%d", tc.Servers[index].Port)}, 15*time.Second)
+	return conn, err
+}
+
+// ConnectAll connects to all servers in the test cluster with the default session timeout.
+func (tc *TestCluster) ConnectAll() (*zk.Conn, <-chan zk.Event, error) {
+	return tc.ConnectAllTimeout(15 * time.Second)
+}
+
+// ConnectAllTimeout connects to all servers with the specified session timeout.
+func (tc *TestCluster) ConnectAllTimeout(sessionTimeout time.Duration) (*zk.Conn, <-chan zk.Event, error) {
+	return tc.ConnectWithOptions(sessionTimeout)
+}
+
+// ConnectWithOptions connects to all servers with the specified session timeout.
+func (tc *TestCluster) ConnectWithOptions(sessionTimeout time.Duration) (*zk.Conn, <-chan zk.Event, error) {
+	hosts := make([]string, len(tc.Servers))
+	for i, srv := range tc.Servers {
+		hosts[i] = fmt.Sprintf("127.0.0.1:%d", srv.Port)
+	}
+	return zk.Connect(hosts, sessionTimeout)
+}
+
+// Stop stops all servers and removes the test cluster data directory.
+func (tc *TestCluster) Stop() error {
+	for _, srv := range tc.Servers {
+		_ = srv.Srv.Stop()
+	}
+	defer func() {
+		_ = os.RemoveAll(tc.Path)
+	}()
+	return tc.waitForStop(5, time.Second)
+}
+
+func (tc *TestCluster) waitForStart(maxRetry int, interval time.Duration) error {
+	serverAddrs := make([]string, len(tc.Servers))
+	for i, server := range tc.Servers {
+		serverAddrs[i] = fmt.Sprintf("127.0.0.1:%d", server.Port)
+	}
+
+	for i := 0; i < maxRetry; i++ {
+		_, ok := zk.FLWSrvr(serverAddrs, time.Second)
+		if ok {
+			return nil
+		}
+		time.Sleep(interval)
+	}
+	return fmt.Errorf("unable to verify health of servers")
+}
+
+func (tc *TestCluster) waitForStop(maxRetry int, interval time.Duration) error {
+	serverAddrs := make([]string, len(tc.Servers))
+	for i, server := range tc.Servers {
+		serverAddrs[i] = fmt.Sprintf("127.0.0.1:%d", server.Port)
+	}
+
+	var success bool
+	for i := 0; i < maxRetry && !success; i++ {
+		success = true
+		for _, ok := range zk.FLWRuok(serverAddrs, time.Second) {
+			if ok {
+				success = false
+			}
+		}
+		if !success {
+			time.Sleep(interval)
+		}
+	}
+	if !success {
+		return fmt.Errorf("unable to verify servers are down")
+	}
+	return nil
+}
+
+// StartServer starts one server selected by address.
+func (tc *TestCluster) StartServer(server string) {
+	for _, testServer := range tc.Servers {
+		if strings.HasSuffix(server, fmt.Sprintf(":%d", testServer.Port)) {
+			_ = testServer.Srv.Start()
+			return
+		}
+	}
+	panic(fmt.Sprintf("unknown server: %s", server))
+}
+
+// StopServer stops one server selected by address.
+func (tc *TestCluster) StopServer(server string) {
+	for _, testServer := range tc.Servers {
+		if strings.HasSuffix(server, fmt.Sprintf(":%d", testServer.Port)) {
+			_ = testServer.Srv.Stop()
+			return
+		}
+	}
+	panic(fmt.Sprintf("unknown server: %s", server))
+}
+
+// StartAllServers starts every server in the test cluster.
+func (tc *TestCluster) StartAllServers() error {
+	for _, server := range tc.Servers {
+		if err := server.Srv.Start(); err != nil {
+			return fmt.Errorf("failed to start server listening on port %d: %w", server.Port, err)
+		}
+	}
+	return nil
+}
+
+// StopAllServers stops every server in the test cluster without removing its data directory.
+func (tc *TestCluster) StopAllServers() error {
+	for _, server := range tc.Servers {
+		if err := server.Srv.Stop(); err != nil {
+			return fmt.Errorf("failed to stop server listening on port %d: %w", server.Port, err)
+		}
+	}
+	return nil
+}

--- a/database/kv/zk/server_java.go
+++ b/database/kv/zk/server_java.go
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Portions of this file are derived from github.com/dubbogo/go-zookeeper.
+ *
+ * Copyright (c) 2013, Samuel Stauffer <samuel@descolada.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package gxzookeeper
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+import (
+	"github.com/dubbogo/go-zookeeper/zk"
+)
+
+// ErrMissingServerConfigField indicates a required ZooKeeper server configuration field is missing.
+type ErrMissingServerConfigField string
+
+func (e ErrMissingServerConfigField) Error() string {
+	return fmt.Sprintf("zk: missing server config field '%s'", string(e))
+}
+
+const (
+	DefaultServerTickTime                 = 2000
+	DefaultServerInitLimit                = 10
+	DefaultServerSyncLimit                = 5
+	DefaultServerAutoPurgeSnapRetainCount = 3
+	DefaultPeerPort                       = 2888
+	DefaultLeaderElectionPort             = 3888
+)
+
+// ServerConfigServer contains the peer configuration for one ZooKeeper server.
+type ServerConfigServer struct {
+	ID                 int
+	Host               string
+	PeerPort           int
+	LeaderElectionPort int
+}
+
+// ServerConfig contains the configuration written to a ZooKeeper server config file.
+type ServerConfig struct {
+	TickTime                 int
+	InitLimit                int
+	SyncLimit                int
+	DataDir                  string
+	ClientPort               int
+	AutoPurgeSnapRetainCount int
+	AutoPurgePurgeInterval   int
+	Servers                  []ServerConfigServer
+}
+
+// Marshall writes the ZooKeeper server configuration.
+func (sc ServerConfig) Marshall(w io.Writer) error {
+	if sc.DataDir == "" {
+		return ErrMissingServerConfigField("dataDir")
+	}
+	if _, err := fmt.Fprintf(w, "dataDir=%s\n", sc.DataDir); err != nil {
+		return err
+	}
+	if sc.TickTime <= 0 {
+		sc.TickTime = DefaultServerTickTime
+	}
+	if _, err := fmt.Fprintf(w, "tickTime=%d\n", sc.TickTime); err != nil {
+		return err
+	}
+	if sc.InitLimit <= 0 {
+		sc.InitLimit = DefaultServerInitLimit
+	}
+	if _, err := fmt.Fprintf(w, "initLimit=%d\n", sc.InitLimit); err != nil {
+		return err
+	}
+	if sc.SyncLimit <= 0 {
+		sc.SyncLimit = DefaultServerSyncLimit
+	}
+	if _, err := fmt.Fprintf(w, "syncLimit=%d\n", sc.SyncLimit); err != nil {
+		return err
+	}
+	if sc.ClientPort <= 0 {
+		sc.ClientPort = zk.DefaultPort
+	}
+	if _, err := fmt.Fprintf(w, "clientPort=%d\n", sc.ClientPort); err != nil {
+		return err
+	}
+	if sc.AutoPurgePurgeInterval > 0 {
+		if sc.AutoPurgeSnapRetainCount <= 0 {
+			sc.AutoPurgeSnapRetainCount = DefaultServerAutoPurgeSnapRetainCount
+		}
+		if _, err := fmt.Fprintf(w, "autopurge.snapRetainCount=%d\n", sc.AutoPurgeSnapRetainCount); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "autopurge.purgeInterval=%d\n", sc.AutoPurgePurgeInterval); err != nil {
+			return err
+		}
+	}
+	for _, srv := range sc.Servers {
+		if srv.PeerPort <= 0 {
+			srv.PeerPort = DefaultPeerPort
+		}
+		if srv.LeaderElectionPort <= 0 {
+			srv.LeaderElectionPort = DefaultLeaderElectionPort
+		}
+		if _, err := fmt.Fprintf(
+			w,
+			"server.%d=%s:%d:%d\n",
+			srv.ID,
+			srv.Host,
+			srv.PeerPort,
+			srv.LeaderElectionPort,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var jarSearchPaths = []string{
+	"zookeeper-*/contrib/fatjar/zookeeper-*-fatjar.jar",
+	"../zookeeper-*/contrib/fatjar/zookeeper-*-fatjar.jar",
+	"/usr/share/java/zookeeper-*.jar",
+	"/usr/local/zookeeper-*/contrib/fatjar/zookeeper-*-fatjar.jar",
+	"/usr/local/Cellar/zookeeper/*/libexec/contrib/fatjar/zookeeper-*-fatjar.jar",
+}
+
+func findZookeeperFatJar() string {
+	var paths []string
+	zkPath := os.Getenv("ZOOKEEPER_PATH")
+	if zkPath == "" {
+		paths = jarSearchPaths
+	} else {
+		paths = []string{filepath.Join(zkPath, "contrib/fatjar/zookeeper-*-fatjar.jar")}
+	}
+	for _, path := range paths {
+		matches, _ := filepath.Glob(path)
+		if len(matches) > 0 {
+			return matches[0]
+		}
+	}
+	return ""
+}
+
+// Server manages one ZooKeeper Java server process.
+type Server struct {
+	JarPath        string
+	ConfigPath     string
+	Stdout, Stderr io.Writer
+
+	cmd *exec.Cmd
+}
+
+// Start starts the ZooKeeper Java server process.
+func (srv *Server) Start() error {
+	if srv.JarPath == "" {
+		srv.JarPath = findZookeeperFatJar()
+		if srv.JarPath == "" {
+			return fmt.Errorf("zk: unable to find server jar")
+		}
+	}
+	srv.cmd = exec.Command("java", "-jar", srv.JarPath, "server", srv.ConfigPath)
+	srv.cmd.Stdout = srv.Stdout
+	srv.cmd.Stderr = srv.Stderr
+	return srv.cmd.Start()
+}
+
+// Stop stops the ZooKeeper Java server process.
+func (srv *Server) Stop() error {
+	if err := srv.cmd.Process.Signal(os.Kill); err != nil {
+		return err
+	}
+	return srv.cmd.Wait()
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/buger/jsonparser v1.1.2
 	github.com/davecgh/go-spew v1.1.1
-	github.com/dubbogo/go-zookeeper v1.0.4-0.20211212162352-f9d2183d89d5
+	github.com/dubbogo/go-zookeeper v1.0.5
 	github.com/k0kubun/pp v3.0.1+incompatible
 	github.com/mattn/go-isatty v0.0.16
 	github.com/nacos-group/nacos-sdk-go/v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dubbogo/go-zookeeper v1.0.4-0.20211212162352-f9d2183d89d5 h1:XoR8SSVziXe698dt4uZYDfsmHpKLemqAgFyndQsq5Kw=
 github.com/dubbogo/go-zookeeper v1.0.4-0.20211212162352-f9d2183d89d5/go.mod h1:fn6n2CAEer3novYgk9ULLwAjuV8/g4DdC2ENwRb6E+c=
+github.com/dubbogo/go-zookeeper v1.0.5 h1:gp7svNO39zoV7RGq5bcN0KjtmFIW8ppLosQJ6CpMC+Q=
+github.com/dubbogo/go-zookeeper v1.0.5/go.mod h1:KAcRdSF5FxSsUCk4KXEIhe4irP6e1jPw7yhxm08hePg=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
**What this PR does**:

This PR fixes the unavailability of ZooKeeper test helper APIs after upgrading `go-zookeeper`.

After upgrading `go-zookeeper` to `v1.0.5`, test helper APIs such as `TestCluster`, `StartTestCluster`, and `WithRetryTimes` were moved into `_test.go` files and could no longer be used directly by downstream modules. As a result, the relevant `gost` test code failed to compile.

This PR migrates these test helpers into `gost` for local maintenance while reusing the original implementation as much as possible to preserve the existing test behavior.

**Which issue(s) this PR fixes**:

This PR fixes a test compatibility issue introduced by the upgrade to `go-zookeeper v1.0.5`.

As this PR only fixes test infrastructure compatibility, it is not associated with a specific business issue.

**Special notes for your reviewer**:

- The changes are limited to ZooKeeper test helper code.
- No production runtime logic or public business APIs are changed.
- The behavior of `TestCluster`, `StartTestCluster`, and `WithRetryTimes` remains consistent with the original implementation.
- The related tests no longer depend on test helpers exposed only through `go-zookeeper` test files.

**Does this PR introduce a user-facing change?**:

```text
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for starting, stopping, and managing local ZooKeeper test clusters.
  * Added Java-based ZooKeeper server configuration and lifecycle management.
  * Added configurable connection retries, timeouts, and server controls.

* **Bug Fixes**
  * Improved cleanup when cluster connection setup fails.
  * Connections now correctly recognize synchronized connected states.
  * Startup failures clean up partially initialized test clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->