### PR TITLE
Fix: etcd grant timeout

### DIFF
--- a/database/kv/etcd/v3/client.go
+++ b/database/kv/etcd/v3/client.go
@@ -44,7 +44,10 @@ var (
 	ErrRevision int64 = -1
 )
 
-const defaultSessionTTL = 60
+const (
+	defaultSessionTTL          = 60
+	defaultInitialGrantTimeout = 5 * time.Second
+)
 
 // NewConfigClient create new Client
 func NewConfigClient(opts ...Option) *Client {
@@ -232,12 +235,12 @@ func (c *Client) keepSession() error {
 		grantTTL = defaultSessionTTL
 	}
 
-	grantCtx := c.ctx
-	if c.timeout > 0 {
-		var cancel context.CancelFunc
-		grantCtx, cancel = context.WithTimeout(c.ctx, c.timeout)
-		defer cancel()
+	grantTimeout := c.timeout
+	if grantTimeout <= 0 {
+		grantTimeout = defaultInitialGrantTimeout
 	}
+	grantCtx, cancel := context.WithTimeout(c.ctx, grantTimeout)
+	defer cancel()
 
 	lease, err := c.rawClient.Grant(grantCtx, int64(grantTTL))
 	if err != nil {

--- a/database/kv/etcd/v3/client.go
+++ b/database/kv/etcd/v3/client.go
@@ -44,6 +44,8 @@ var (
 	ErrRevision int64 = -1
 )
 
+const defaultSessionTTL = 60
+
 // NewConfigClient create new Client
 func NewConfigClient(opts ...Option) *Client {
 	newClient, err := NewConfigClientWithErr(opts...)
@@ -123,6 +125,7 @@ func NewClient(name string, endpoints []string, timeout time.Duration, heartbeat
 
 	if err := c.keepSession(); err != nil {
 		cancel()
+		_ = rawClient.Close()
 		return nil, perrors.WithMessage(err, "client keep session")
 	}
 	return c, nil
@@ -163,6 +166,7 @@ func NewClientWithOptions(ctx context.Context, opts *Options) (*Client, error) {
 
 	if err := c.keepSession(); err != nil {
 		cancel()
+		_ = rawClient.Close()
 		return nil, perrors.WithMessage(err, "client keep session")
 	}
 	return c, nil
@@ -223,8 +227,31 @@ func (c *Client) Close() {
 }
 
 func (c *Client) keepSession() error {
-	s, err := concurrency.NewSession(c.rawClient, concurrency.WithTTL(c.heartbeat))
+	grantTTL := c.heartbeat
+	if grantTTL <= 0 {
+		grantTTL = defaultSessionTTL
+	}
+
+	grantCtx := c.ctx
+	if c.timeout > 0 {
+		var cancel context.CancelFunc
+		grantCtx, cancel = context.WithTimeout(c.ctx, c.timeout)
+		defer cancel()
+	}
+
+	lease, err := c.rawClient.Grant(grantCtx, int64(grantTTL))
 	if err != nil {
+		return perrors.WithMessage(err, "grant session lease")
+	}
+
+	s, err := concurrency.NewSession(c.rawClient,
+		concurrency.WithTTL(c.heartbeat),
+		concurrency.WithLease(lease.ID),
+	)
+	if err != nil {
+		revokeCtx, cancel := context.WithTimeout(c.ctx, time.Second)
+		_, _ = c.rawClient.Revoke(revokeCtx, lease.ID)
+		cancel()
 		return perrors.WithMessage(err, "new session with server")
 	}
 

--- a/database/kv/etcd/v3/client_test.go
+++ b/database/kv/etcd/v3/client_test.go
@@ -18,6 +18,8 @@
 package gxetcd
 
 import (
+	"context"
+	"net"
 	"net/url"
 	"os"
 	"path"
@@ -34,6 +36,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"go.etcd.io/etcd/server/v3/embed"
 
@@ -149,6 +152,98 @@ func (suite *ClientTestSuite) TestClientClose() {
 	if c.rawClient.ActiveConnection().GetState() != connectivity.Ready {
 		t.Fatal(suite.client.rawClient.ActiveConnection().GetState())
 	}
+}
+
+func TestNewClientWithOptionsTimeoutsInitialGrant(t *testing.T) {
+	const timeout = 100 * time.Millisecond
+
+	embed.SetupGrpcLoggingForTest(false)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	listenerDone := make(chan struct{})
+	go func() {
+		defer close(listenerDone)
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close()
+		<-ctx.Done()
+	}()
+	t.Cleanup(func() {
+		cancel()
+		_ = listener.Close()
+		<-listenerDone
+	})
+
+	started := time.Now()
+	done := make(chan error, 1)
+	go func() {
+		_, clientErr := NewClientWithOptions(ctx, &Options{
+			Endpoints: []string{listener.Addr().String()},
+			Timeout:   timeout,
+			Heartbeat: 1,
+		})
+		done <- clientErr
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected client initialization to fail")
+		}
+		if !strings.Contains(err.Error(), "grant session lease") {
+			t.Fatalf("expected grant session lease error, got %v", err)
+		}
+		if elapsed := time.Since(started); elapsed > time.Second {
+			t.Fatalf("client initialization took too long: %s", elapsed)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("client initialization did not respect the grant timeout")
+	}
+}
+
+func (suite *ClientTestSuite) TestKeepSessionUsesDefaultTTL() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	before, err := suite.client.rawClient.Leases(ctx)
+	suite.Require().NoError(err)
+	existingLeases := make(map[clientv3.LeaseID]struct{}, len(before.Leases))
+	for _, lease := range before.Leases {
+		existingLeases[lease.ID] = struct{}{}
+	}
+
+	c, err := NewConfigClientWithErr(
+		WithName(suite.etcdConfig.name),
+		WithEndpoints(suite.etcdConfig.endpoints...),
+		WithTimeout(suite.etcdConfig.timeout),
+		WithHeartbeat(0),
+	)
+	suite.Require().NoError(err)
+	defer c.Close()
+
+	after, err := c.rawClient.Leases(ctx)
+	suite.Require().NoError(err)
+	newLeases := make([]clientv3.LeaseID, 0, 1)
+	for _, lease := range after.Leases {
+		if _, ok := existingLeases[lease.ID]; !ok {
+			newLeases = append(newLeases, lease.ID)
+		}
+	}
+	suite.Require().Len(newLeases, 1)
+
+	ttl, err := c.rawClient.TimeToLive(ctx, newLeases[0])
+	suite.Require().NoError(err)
+	suite.Equal(int64(defaultSessionTTL), ttl.GrantedTTL)
+
+	_, err = c.rawClient.Revoke(ctx, newLeases[0])
+	suite.Require().NoError(err)
 }
 
 func (suite *ClientTestSuite) TestClientValid() {


### PR DESCRIPTION
**What this PR does**:

This PR fixes the issue where client initialization and related tests could time out when the etcd service was unavailable.

Previously, `gost` removed `grpc.WithBlock()`, allowing `grpc.DialContext` to return before the connection reached the `Ready` state. The existing `DialTimeout` only covered the dialing process and did not apply to the subsequent initial `Grant` request in `keepSession`. When the etcd service was not running, the initial `Grant` used the long-lived client context and could wait indefinitely, eventually causing the tests to time out.

This PR uses a separate short-lived timeout context for the initial `Grant` request in `keepSession`. After the grant succeeds, its lease ID is passed to `NewSession`, which continues to use the long-lived context for KeepAlive.

This PR preserves the asynchronous dialing behavior introduced by removing `grpc.WithBlock()` and does not restore synchronous dialing.

**Which issue(s) this PR fixes**:

This PR fixes the test initialization timeout when the etcd service is unavailable. It is not associated with a specific business issue.

**Special notes for your reviewer**:

- When `Options.Timeout > 0`, the initial `Grant` uses a separate timeout.
- When `Options.Timeout <= 0`, the existing behavior without a deadline is preserved.
- The existing behavior of using the default session TTL when `heartbeat <= 0` is preserved.
- After a successful `Grant`, the session is created with `WithLease` to avoid requesting another lease.
- Tests covering the initial `Grant` timeout and the default heartbeat TTL have been added.
- No public APIs are changed, and `grpc.WithBlock()` is not restored.

**Does this PR introduce a user-facing change?**:

```
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved etcd client initialization reliability with configurable session lease timeouts.
  * Added default values of 60 seconds for session lifetime and 5 seconds for the initial lease grant.
  * Prevented initialization from hanging when an endpoint is unreachable or unresponsive.
  * Ensured failed session setup cleans up connections and leases properly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->