### PR TITLE
Migrate database/kv/zk from dubbogo/go-zookeeper fork to upstream go-zookeeper/zk

### DIFF
--- a/database/kv/zk/client.go
+++ b/database/kv/zk/client.go
@@ -164,19 +164,19 @@ func (z *ZookeeperClient) createZookeeperConn() error {
 	return nil
 }
 
-// zkMockAddrEnvKey is the environment variable used to tell NewMockZookeeperClient
+// zkAddrEnvKey is the environment variable used to tell NewZookeeperClientFromEnv
 // which real zookeeper server it should connect to.
-const zkMockAddrEnvKey = "ZK_ADDR"
+const zkAddrEnvKey = "ZK_ADDR"
 
-// defaultZkMockAddr is used by NewMockZookeeperClient when the ZK_ADDR
+// defaultZkAddr is used by NewZookeeperClientFromEnv when the ZK_ADDR
 // environment variable is not set.
-const defaultZkMockAddr = "127.0.0.1:2181"
+const defaultZkAddr = "127.0.0.1:2181"
 
-// dialProbeTimeout bounds the reachability check NewMockZookeeperClient
+// dialProbeTimeout bounds the reachability check NewZookeeperClientFromEnv
 // performs before calling zk.Connect.
 const dialProbeTimeout = 5 * time.Second
 
-// sessionEstablishTimeout bounds how long NewMockZookeeperClient and
+// sessionEstablishTimeout bounds how long NewZookeeperClientFromEnv and
 // waitForSession will wait for a freshly dialed connection to reach
 // zk.StateHasSession.
 const sessionEstablishTimeout = 5 * time.Second
@@ -203,14 +203,16 @@ func waitForSession(conn *zk.Conn, timeout, pollInterval time.Duration) error {
 	}
 }
 
-// NewMockZookeeperClient returns a ZookeeperClient instance for testing purposes.
+// NewZookeeperClientFromEnv returns a ZookeeperClient instance that connects
+// to a real zookeeper server named by the ZK_ADDR environment variable
+// (defaulting to "127.0.0.1:2181" when unset). It is intended for tests and
+// local development, not production use.
 //
-// It dials the zookeeper server named by the ZK_ADDR environment variable
-// (defaulting to "127.0.0.1:2181" when unset) and blocks until the resulting
-// connection reaches zk.StateHasSession or sessionEstablishTimeout elapses.
-// Callers are responsible for starting that zookeeper server beforehand and
-// should Close() the returned *ZookeeperClient once done with it.
-func NewMockZookeeperClient(name string, timeout time.Duration, opts ...Option) (*ZookeeperClient, <-chan zk.Event, error) {
+// It blocks until the resulting connection reaches zk.StateHasSession or
+// sessionEstablishTimeout elapses. Callers are responsible for starting that
+// zookeeper server beforehand and should Close() the returned
+// *ZookeeperClient once done with it.
+func NewZookeeperClientFromEnv(name string, timeout time.Duration, opts ...Option) (*ZookeeperClient, <-chan zk.Event, error) {
 	var err error
 
 	z := &ZookeeperClient{
@@ -229,9 +231,9 @@ func NewMockZookeeperClient(name string, timeout time.Duration, opts ...Option) 
 		opt(option)
 	}
 
-	addr := os.Getenv(zkMockAddrEnvKey)
+	addr := os.Getenv(zkAddrEnvKey)
 	if addr == "" {
-		addr = defaultZkMockAddr
+		addr = defaultZkAddr
 	}
 	z.ZkAddrs = []string{addr}
 
@@ -242,7 +244,7 @@ func NewMockZookeeperClient(name string, timeout time.Duration, opts ...Option) 
 	// of hanging on the first operation.
 	probeConn, probeErr := net.DialTimeout("tcp", addr, dialProbeTimeout)
 	if probeErr != nil {
-		return nil, nil, perrors.WithMessagef(probeErr, "no zookeeper server reachable at %s (set %s to point at one)", addr, zkMockAddrEnvKey)
+		return nil, nil, perrors.WithMessagef(probeErr, "no zookeeper server reachable at %s (set %s to point at one)", addr, zkAddrEnvKey)
 	}
 	_ = probeConn.Close()
 

--- a/database/kv/zk/client.go
+++ b/database/kv/zk/client.go
@@ -18,6 +18,8 @@
 package gxzookeeper
 
 import (
+	"net"
+	"os"
 	"path"
 	"strings"
 	"sync"
@@ -26,7 +28,7 @@ import (
 )
 
 import (
-	"github.com/dubbogo/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 
 	perrors "github.com/pkg/errors"
 )
@@ -162,22 +164,37 @@ func (z *ZookeeperClient) createZookeeperConn() error {
 	return nil
 }
 
-// WithTestCluster sets test cluster for zk Client
-func WithTestCluster(ts *zk.TestCluster) Option {
-	return func(opt *options) {
-		opt.Ts = ts
-	}
-}
+// zkMockAddrEnvKey is the environment variable used to tell NewMockZookeeperClient
+// which real zookeeper server it should connect to.
+const zkMockAddrEnvKey = "ZK_ADDR"
 
-// NewMockZookeeperClient returns a mock Client instance
-func NewMockZookeeperClient(name string, timeout time.Duration, opts ...Option) (*zk.TestCluster, *ZookeeperClient, <-chan zk.Event, error) {
-	var (
-		err error
-		z   *ZookeeperClient
-		ts  *zk.TestCluster
-	)
+// defaultZkMockAddr is used by NewMockZookeeperClient when the ZK_ADDR
+// environment variable is not set.
+const defaultZkMockAddr = "127.0.0.1:2181"
 
-	z = &ZookeeperClient{
+// dialProbeTimeout bounds the reachability check NewMockZookeeperClient does
+// before handing back a client, see the note on that function.
+const dialProbeTimeout = 5 * time.Second
+
+// NewMockZookeeperClient returns a ZookeeperClient instance for testing purposes.
+//
+// NOTE: behavior changed as part of the migration off the forked
+// github.com/dubbogo/go-zookeeper package. This function used to boot an
+// in-process zk server via that fork's TestCluster. The upstream
+// github.com/go-zookeeper/zk package this project now depends on does not
+// expose an importable TestCluster/StartTestCluster API (it only exists in
+// the upstream module's _test.go files), so an embedded server can no longer
+// be started here. NewMockZookeeperClient now dials a real zookeeper server
+// instead; configure its address via the ZK_ADDR environment variable
+// (defaults to "127.0.0.1:2181" when unset). Callers are responsible for
+// starting/stopping that zookeeper server themselves (e.g. via docker) around
+// the test run. The previously returned *zk.TestCluster value is gone since
+// the type no longer exists; callers should just Close() the returned
+// *ZookeeperClient instead of stopping a test cluster.
+func NewMockZookeeperClient(name string, timeout time.Duration, opts ...Option) (*ZookeeperClient, <-chan zk.Event, error) {
+	var err error
+
+	z := &ZookeeperClient{
 		name:           name,
 		ZkAddrs:        []string{},
 		Timeout:        timeout,
@@ -193,23 +210,32 @@ func NewMockZookeeperClient(name string, timeout time.Duration, opts ...Option) 
 		opt(option)
 	}
 
-	// connect to zookeeper
-	if option.Ts != nil {
-		ts = option.Ts
-	} else {
-		ts, err = zk.StartTestCluster(1, nil, nil, zk.WithRetryTimes(40))
-		if err != nil {
-			return nil, nil, nil, perrors.WithMessagef(err, "zk.StartTestCluster fail")
-		}
+	addr := os.Getenv(zkMockAddrEnvKey)
+	if addr == "" {
+		addr = defaultZkMockAddr
 	}
+	z.ZkAddrs = []string{addr}
 
-	z.Conn, z.Session, err = ts.ConnectWithOptions(timeout)
+	// zk.Connect only fails on a malformed/empty server list: it dials in a
+	// background goroutine and otherwise returns immediately, so it would
+	// silently hand back a client marked valid even with nothing listening.
+	// Probe reachability up front so callers still get an explicit error
+	// instead of hanging on the first operation, matching the old contract
+	// where StartTestCluster guaranteed a live server before returning.
+	probeConn, probeErr := net.DialTimeout("tcp", addr, dialProbeTimeout)
+	if probeErr != nil {
+		return nil, nil, perrors.WithMessagef(probeErr, "no zookeeper server reachable at %s (set %s to point at one)", addr, zkMockAddrEnvKey)
+	}
+	_ = probeConn.Close()
+
+	// connect to a real zookeeper server, see the NOTE above.
+	z.Conn, z.Session, err = zk.Connect(z.ZkAddrs, timeout)
 	if err != nil {
-		return nil, nil, nil, perrors.WithMessagef(err, "zk.Connect fail")
+		return nil, nil, perrors.WithMessagef(err, "zk.Connect fail")
 	}
 	atomic.StoreUint32(&z.valid, 1)
 	z.activeNumber++
-	return ts, z, z.Session, nil
+	return z, z.Session, nil
 }
 
 // HandleZkEvent handles zookeeper events
@@ -425,7 +451,7 @@ func (z *ZookeeperClient) GetChildrenW(path string) ([]string, <-chan zk.Event, 
 	if conn == nil {
 		return nil, nil, ErrNilZkClientConn
 	}
-	children, stat, watcher, err := conn.ChildrenW(path)
+	children, stat, watchCh, err := conn.ChildrenW(path)
 
 	if err != nil {
 		return nil, nil, perrors.WithMessagef(err, "Error while invoking zk.ChildrenW(path:%s), the reason maybe is: ", path)
@@ -434,7 +460,7 @@ func (z *ZookeeperClient) GetChildrenW(path string) ([]string, <-chan zk.Event, 
 		return nil, nil, perrors.WithMessagef(ErrStatIsNil, "Error while invokeing zk.ChildrenW(path:%s), the reason is: ", path)
 	}
 
-	return children, watcher.EvtCh, nil
+	return children, watchCh, nil
 }
 
 // GetChildren gets children by @path
@@ -461,13 +487,13 @@ func (z *ZookeeperClient) ExistW(zkPath string) (<-chan zk.Event, error) {
 	if conn == nil {
 		return nil, ErrNilZkClientConn
 	}
-	_, _, watcher, err := conn.ExistsW(zkPath)
+	_, _, watchCh, err := conn.ExistsW(zkPath)
 
 	if err != nil {
 		return nil, perrors.WithMessagef(err, "zk.ExistsW(path:%s)", zkPath)
 	}
 
-	return watcher.EvtCh, nil
+	return watchCh, nil
 }
 
 // GetContent gets content by @zkPath

--- a/database/kv/zk/client.go
+++ b/database/kv/zk/client.go
@@ -172,25 +172,44 @@ const zkMockAddrEnvKey = "ZK_ADDR"
 // environment variable is not set.
 const defaultZkMockAddr = "127.0.0.1:2181"
 
-// dialProbeTimeout bounds the reachability check NewMockZookeeperClient does
-// before handing back a client, see the note on that function.
+// dialProbeTimeout bounds the reachability check NewMockZookeeperClient
+// performs before calling zk.Connect.
 const dialProbeTimeout = 5 * time.Second
+
+// sessionEstablishTimeout bounds how long NewMockZookeeperClient and
+// waitForSession will wait for a freshly dialed connection to reach
+// zk.StateHasSession.
+const sessionEstablishTimeout = 5 * time.Second
+
+// sessionPollInterval is the polling interval waitForSession uses while
+// waiting for a connection to reach zk.StateHasSession.
+const sessionPollInterval = 50 * time.Millisecond
+
+// waitForSession blocks until conn reports zk.StateHasSession, polling its
+// State() at pollInterval, and returns an error if timeout elapses first.
+// It never reads from conn's event channel, so callers that still need to
+// observe the full initial event sequence on that channel can do so
+// afterwards without having lost any events to this wait.
+func waitForSession(conn *zk.Conn, timeout, pollInterval time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if conn.State() == zk.StateHasSession {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return perrors.Errorf("timed out after %s waiting for zookeeper session", timeout)
+		}
+		time.Sleep(pollInterval)
+	}
+}
 
 // NewMockZookeeperClient returns a ZookeeperClient instance for testing purposes.
 //
-// NOTE: behavior changed as part of the migration off the forked
-// github.com/dubbogo/go-zookeeper package. This function used to boot an
-// in-process zk server via that fork's TestCluster. The upstream
-// github.com/go-zookeeper/zk package this project now depends on does not
-// expose an importable TestCluster/StartTestCluster API (it only exists in
-// the upstream module's _test.go files), so an embedded server can no longer
-// be started here. NewMockZookeeperClient now dials a real zookeeper server
-// instead; configure its address via the ZK_ADDR environment variable
-// (defaults to "127.0.0.1:2181" when unset). Callers are responsible for
-// starting/stopping that zookeeper server themselves (e.g. via docker) around
-// the test run. The previously returned *zk.TestCluster value is gone since
-// the type no longer exists; callers should just Close() the returned
-// *ZookeeperClient instead of stopping a test cluster.
+// It dials the zookeeper server named by the ZK_ADDR environment variable
+// (defaulting to "127.0.0.1:2181" when unset) and blocks until the resulting
+// connection reaches zk.StateHasSession or sessionEstablishTimeout elapses.
+// Callers are responsible for starting that zookeeper server beforehand and
+// should Close() the returned *ZookeeperClient once done with it.
 func NewMockZookeeperClient(name string, timeout time.Duration, opts ...Option) (*ZookeeperClient, <-chan zk.Event, error) {
 	var err error
 
@@ -219,20 +238,28 @@ func NewMockZookeeperClient(name string, timeout time.Duration, opts ...Option) 
 	// zk.Connect only fails on a malformed/empty server list: it dials in a
 	// background goroutine and otherwise returns immediately, so it would
 	// silently hand back a client marked valid even with nothing listening.
-	// Probe reachability up front so callers still get an explicit error
-	// instead of hanging on the first operation, matching the old contract
-	// where StartTestCluster guaranteed a live server before returning.
+	// Probe reachability up front so callers get an explicit error instead
+	// of hanging on the first operation.
 	probeConn, probeErr := net.DialTimeout("tcp", addr, dialProbeTimeout)
 	if probeErr != nil {
 		return nil, nil, perrors.WithMessagef(probeErr, "no zookeeper server reachable at %s (set %s to point at one)", addr, zkMockAddrEnvKey)
 	}
 	_ = probeConn.Close()
 
-	// connect to a real zookeeper server, see the NOTE above.
+	// connect to a real zookeeper server, see the doc comment above.
 	z.Conn, z.Session, err = zk.Connect(z.ZkAddrs, timeout)
 	if err != nil {
 		return nil, nil, perrors.WithMessagef(err, "zk.Connect fail")
 	}
+
+	// zk.Connect dials in a background goroutine and returns before the
+	// session handshake completes, so wait for it here rather than handing
+	// back a client that looks valid but isn't usable yet.
+	if err := waitForSession(z.Conn, sessionEstablishTimeout, sessionPollInterval); err != nil {
+		z.Conn.Close()
+		return nil, nil, perrors.WithMessagef(err, "zk.Connect to %s", strings.Join(z.ZkAddrs, ","))
+	}
+
 	atomic.StoreUint32(&z.valid, 1)
 	z.activeNumber++
 	return z, z.Session, nil

--- a/database/kv/zk/client_test.go
+++ b/database/kv/zk/client_test.go
@@ -18,16 +18,65 @@
 package gxzookeeper
 
 import (
-	"strconv"
+	"net"
+	"os"
+	"path"
 	"testing"
 	"time"
 )
 
 import (
-	"github.com/dubbogo/go-zookeeper/zk"
+	"github.com/go-zookeeper/zk"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// zkTestAddrEnvKey is the environment variable used to point these tests at
+// a real zookeeper server.
+const zkTestAddrEnvKey = "ZK_ADDR"
+
+// defaultZkTestAddr is used when ZK_ADDR is not set.
+const defaultZkTestAddr = "127.0.0.1:2181"
+
+// testZkAddr returns the zookeeper address these tests should run against.
+//
+// github.com/go-zookeeper/zk (the upstream package this module now depends
+// on) does not expose an importable TestCluster/StartTestCluster API the
+// way the previous github.com/dubbogo/go-zookeeper fork did (upstream only
+// has it in the module's own _test.go files, which cannot be imported), so
+// these tests can no longer boot an in-process zk server on demand. Instead
+// they require a real, reachable zookeeper server; point ZK_ADDR at one
+// (defaults to 127.0.0.1:2181). When no server is reachable, the calling
+// test is skipped rather than failed.
+func testZkAddr(t *testing.T) string {
+	addr := os.Getenv(zkTestAddrEnvKey)
+	if addr == "" {
+		addr = defaultZkTestAddr
+	}
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Skipf("skipping: no zookeeper server reachable at %s (set %s to run this test): %v", addr, zkTestAddrEnvKey, err)
+		return ""
+	}
+	_ = conn.Close()
+	return addr
+}
+
+// cleanupZkPath best-effort recursively removes a zk path (and its
+// children) so tests that assert on Create() are repeatable against a
+// long-lived real zk server instead of a freshly booted test cluster.
+func cleanupZkPath(z *ZookeeperClient, zkPath string) {
+	if z == nil || z.Conn == nil {
+		return
+	}
+	children, _, err := z.Conn.Children(zkPath)
+	if err == nil {
+		for _, c := range children {
+			cleanupZkPath(z, path.Join(zkPath, c))
+		}
+	}
+	_ = z.Conn.Delete(zkPath, -1)
+}
 
 func verifyEventStateOrder(t *testing.T, c <-chan zk.Event, expectedStates []zk.State, source string) {
 	for _, state := range expectedStates {
@@ -49,14 +98,9 @@ func verifyEventStateOrder(t *testing.T, c <-chan zk.Event, expectedStates []zk.
 }
 
 func Test_getZookeeperClient(t *testing.T) {
-	var err error
-	var tc *zk.TestCluster
-	var address []string
-	tc, err = zk.StartTestCluster(1, nil, nil, zk.WithRetryTimes(40))
-	assert.NoError(t, err)
-	assert.NotNil(t, tc.Servers[0])
+	addr := testZkAddr(t)
+	address := []string{addr}
 
-	address = append(address, "127.0.0.1:"+strconv.Itoa(tc.Servers[0].Port))
 	client1, err := NewZookeeperClient("test1", address, true, WithZkTimeOut(3*time.Second))
 	assert.Nil(t, err)
 	client2, err := NewZookeeperClient("test1", address, true, WithZkTimeOut(3*time.Second))
@@ -78,17 +122,12 @@ func Test_getZookeeperClient(t *testing.T) {
 	client2.Close()
 	client3.Close()
 	client4.Close()
-	_ = tc.Stop()
 }
 
 func Test_Close(t *testing.T) {
-	var err error
-	var tc *zk.TestCluster
-	var address []string
-	tc, err = zk.StartTestCluster(1, nil, nil, zk.WithRetryTimes(40))
-	assert.NoError(t, err)
-	assert.NotNil(t, tc.Servers[0])
-	address = append(address, "127.0.0.1:"+strconv.Itoa(tc.Servers[0].Port))
+	addr := testZkAddr(t)
+	address := []string{addr}
+
 	client1, err := NewZookeeperClient("test1", address, true, WithZkTimeOut(3*time.Second))
 	assert.Nil(t, err)
 	client2, err := NewZookeeperClient("test1", address, true, WithZkTimeOut(3*time.Second))
@@ -126,44 +165,45 @@ func Test_Close(t *testing.T) {
 	client6.Close()
 	assert.Equal(t, client6.activeNumber, uint32(0))
 	assert.Equal(t, client6.Conn, (*zk.Conn)(nil))
-	_ = tc.Stop()
+	client4.Close()
 }
 
 func Test_newMockZookeeperClient(t *testing.T) {
-	ts, _, event, err := NewMockZookeeperClient("test", 15*time.Second)
+	testZkAddr(t)
+
+	z, event, err := NewMockZookeeperClient("test", 15*time.Second)
 	assert.NoError(t, err)
-	defer func() {
-		err := ts.Stop()
-		assert.Nil(t, err)
-	}()
+	defer z.Close()
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
 }
 
 func TestCreate(t *testing.T) {
-	ts, z, event, err := NewMockZookeeperClient("test", 15*time.Second)
+	testZkAddr(t)
+
+	z, event, err := NewMockZookeeperClient("test", 15*time.Second)
 	assert.NoError(t, err)
-	defer func() {
-		_ = ts.Stop()
-		assert.Nil(t, err)
-	}()
-	err = z.Create("/test1/test2/test3/test4")
-	assert.NoError(t, err)
+	defer z.Close()
 
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
+
+	cleanupZkPath(z, "/test1")
+	err = z.Create("/test1/test2/test3/test4")
+	assert.NoError(t, err)
 }
 
 func TestCreateDelete(t *testing.T) {
-	ts, z, event, err := NewMockZookeeperClient("test", 15*time.Second)
+	testZkAddr(t)
+
+	z, event, err := NewMockZookeeperClient("test", 15*time.Second)
 	assert.NoError(t, err)
-	defer func() {
-		_ = ts.Stop()
-		assert.Nil(t, err)
-	}()
+	defer z.Close()
 
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
+
+	cleanupZkPath(z, "/test1")
 	err = z.Create("/test1/test2/test3/test4")
 	assert.NoError(t, err)
 	err = z.Delete("/test1/test2/test3/test4")
@@ -172,12 +212,13 @@ func TestCreateDelete(t *testing.T) {
 }
 
 func TestRegisterTemp(t *testing.T) {
-	ts, z, event, err := NewMockZookeeperClient("test", 15*time.Second)
+	testZkAddr(t)
+
+	z, event, err := NewMockZookeeperClient("test", 15*time.Second)
 	assert.NoError(t, err)
-	defer func() {
-		_ = ts.Stop()
-		assert.Nil(t, err)
-	}()
+	defer z.Close()
+
+	cleanupZkPath(z, "/test1")
 	err = z.Create("/test1/test2/test3")
 	assert.NoError(t, err)
 
@@ -189,12 +230,13 @@ func TestRegisterTemp(t *testing.T) {
 }
 
 func TestRegisterTempSeq(t *testing.T) {
-	ts, z, event, err := NewMockZookeeperClient("test", 15*time.Second)
+	testZkAddr(t)
+
+	z, event, err := NewMockZookeeperClient("test", 15*time.Second)
 	assert.NoError(t, err)
-	defer func() {
-		_ = ts.Stop()
-		assert.Nil(t, err)
-	}()
+	defer z.Close()
+
+	cleanupZkPath(z, "/test1")
 	err = z.Create("/test1/test2/test3")
 	assert.NoError(t, err)
 	tmpath, err := z.RegisterTempSeq("/test1/test2/test3", []byte("test"))

--- a/database/kv/zk/client_test.go
+++ b/database/kv/zk/client_test.go
@@ -206,14 +206,16 @@ func Test_Close(t *testing.T) {
 	client4.Close()
 }
 
-// Test_newMockZookeeperClient verifies that NewMockZookeeperClient connects
+// Test_newZookeeperClientFromEnv verifies that NewZookeeperClientFromEnv connects
 // successfully and that its event channel delivers the expected sequence of
 // session state events.
-func Test_newMockZookeeperClient(t *testing.T) {
+func Test_newZookeeperClientFromEnv(t *testing.T) {
 	testZkAddr(t)
 
-	z, event, err := NewMockZookeeperClient("test", 15*time.Second)
-	assert.NoError(t, err)
+	z, event, err := NewZookeeperClientFromEnv("test", 15*time.Second)
+	if !assert.NoError(t, err) {
+		return
+	}
 	defer z.Close()
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
@@ -224,8 +226,10 @@ func Test_newMockZookeeperClient(t *testing.T) {
 func TestCreate(t *testing.T) {
 	testZkAddr(t)
 
-	z, event, err := NewMockZookeeperClient("test", 15*time.Second)
-	assert.NoError(t, err)
+	z, event, err := NewZookeeperClientFromEnv("test", 15*time.Second)
+	if !assert.NoError(t, err) {
+		return
+	}
 	defer z.Close()
 	defer cleanupZkPath(z, testRootPath)
 
@@ -242,8 +246,10 @@ func TestCreate(t *testing.T) {
 func TestCreateDelete(t *testing.T) {
 	testZkAddr(t)
 
-	z, event, err := NewMockZookeeperClient("test", 15*time.Second)
-	assert.NoError(t, err)
+	z, event, err := NewZookeeperClientFromEnv("test", 15*time.Second)
+	if !assert.NoError(t, err) {
+		return
+	}
 	defer z.Close()
 	defer cleanupZkPath(z, testRootPath)
 
@@ -263,8 +269,10 @@ func TestCreateDelete(t *testing.T) {
 func TestRegisterTemp(t *testing.T) {
 	testZkAddr(t)
 
-	z, event, err := NewMockZookeeperClient("test", 15*time.Second)
-	assert.NoError(t, err)
+	z, event, err := NewZookeeperClientFromEnv("test", 15*time.Second)
+	if !assert.NoError(t, err) {
+		return
+	}
 	defer z.Close()
 	defer cleanupZkPath(z, testRootPath)
 
@@ -285,8 +293,10 @@ func TestRegisterTemp(t *testing.T) {
 func TestRegisterTempSeq(t *testing.T) {
 	testZkAddr(t)
 
-	z, event, err := NewMockZookeeperClient("test", 15*time.Second)
-	assert.NoError(t, err)
+	z, event, err := NewZookeeperClientFromEnv("test", 15*time.Second)
+	if !assert.NoError(t, err) {
+		return
+	}
 	defer z.Close()
 	defer cleanupZkPath(z, testRootPath)
 

--- a/database/kv/zk/client_test.go
+++ b/database/kv/zk/client_test.go
@@ -18,6 +18,9 @@
 package gxzookeeper
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
 	"net"
 	"os"
 	"path"
@@ -38,16 +41,29 @@ const zkTestAddrEnvKey = "ZK_ADDR"
 // defaultZkTestAddr is used when ZK_ADDR is not set.
 const defaultZkTestAddr = "127.0.0.1:2181"
 
-// testZkAddr returns the zookeeper address these tests should run against.
-//
-// github.com/go-zookeeper/zk (the upstream package this module now depends
-// on) does not expose an importable TestCluster/StartTestCluster API the
-// way the previous github.com/dubbogo/go-zookeeper fork did (upstream only
-// has it in the module's own _test.go files, which cannot be imported), so
-// these tests can no longer boot an in-process zk server on demand. Instead
-// they require a real, reachable zookeeper server; point ZK_ADDR at one
-// (defaults to 127.0.0.1:2181). When no server is reachable, the calling
-// test is skipped rather than failed.
+// testRootPath is a zookeeper path unique to this test run, generated once
+// per package invocation by newTestRootPath. Every test derives its node
+// paths from it and cleanupZkPath only ever clears this path, so tests keep
+// working against a shared, long-lived zookeeper server without touching
+// data created by other test runs or other clients.
+var testRootPath = newTestRootPath()
+
+// newTestRootPath returns a randomly named root path of the form
+// "/gost-test-<hex>", used to give each test run its own zookeeper
+// namespace.
+func newTestRootPath() string {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		panic(fmt.Sprintf("newTestRootPath: %v", err))
+	}
+	return "/gost-test-" + hex.EncodeToString(buf)
+}
+
+// testZkAddr returns the zookeeper address these tests should run against,
+// reading the ZK_ADDR environment variable and falling back to
+// 127.0.0.1:2181 when it is unset. It verifies the server is reachable and
+// waits for a probe connection to reach zk.StateHasSession, skipping the
+// calling test if either check fails or times out.
 func testZkAddr(t *testing.T) string {
 	addr := os.Getenv(zkTestAddrEnvKey)
 	if addr == "" {
@@ -59,12 +75,25 @@ func testZkAddr(t *testing.T) string {
 		return ""
 	}
 	_ = conn.Close()
+
+	probe, _, err := zk.Connect([]string{addr}, time.Second)
+	if err != nil {
+		t.Skipf("skipping: could not connect to zookeeper at %s: %v", addr, err)
+		return ""
+	}
+	defer probe.Close()
+	if err := waitForSession(probe, sessionEstablishTimeout, sessionPollInterval); err != nil {
+		t.Skipf("skipping: zookeeper at %s never reported a session: %v", addr, err)
+		return ""
+	}
+
 	return addr
 }
 
-// cleanupZkPath best-effort recursively removes a zk path (and its
-// children) so tests that assert on Create() are repeatable against a
-// long-lived real zk server instead of a freshly booted test cluster.
+// cleanupZkPath best-effort recursively removes zkPath and all of its
+// descendants, letting tests clear their run-scoped root (testRootPath)
+// before creating nodes so runs are repeatable against a shared, long-lived
+// real zk server instead of a freshly booted test cluster.
 func cleanupZkPath(z *ZookeeperClient, zkPath string) {
 	if z == nil || z.Conn == nil {
 		return
@@ -78,6 +107,9 @@ func cleanupZkPath(z *ZookeeperClient, zkPath string) {
 	_ = z.Conn.Delete(zkPath, -1)
 }
 
+// verifyEventStateOrder asserts that c delivers session events whose states
+// match expectedStates, in order, failing t if the channel closes early or
+// the states diverge.
 func verifyEventStateOrder(t *testing.T, c <-chan zk.Event, expectedStates []zk.State, source string) {
 	for _, state := range expectedStates {
 		for {
@@ -97,6 +129,9 @@ func verifyEventStateOrder(t *testing.T, c <-chan zk.Event, expectedStates []zk.
 	}
 }
 
+// Test_getZookeeperClient verifies that NewZookeeperClient returns the same
+// *ZookeeperClient for repeated calls with the same name when share is true,
+// and distinct clients otherwise.
 func Test_getZookeeperClient(t *testing.T) {
 	addr := testZkAddr(t)
 	address := []string{addr}
@@ -124,6 +159,9 @@ func Test_getZookeeperClient(t *testing.T) {
 	client4.Close()
 }
 
+// Test_Close verifies that Close decrements a shared client's reference
+// count and only closes the underlying connection once that count reaches
+// zero, while non-shared clients close independently of one another.
 func Test_Close(t *testing.T) {
 	addr := testZkAddr(t)
 	address := []string{addr}
@@ -168,6 +206,9 @@ func Test_Close(t *testing.T) {
 	client4.Close()
 }
 
+// Test_newMockZookeeperClient verifies that NewMockZookeeperClient connects
+// successfully and that its event channel delivers the expected sequence of
+// session state events.
 func Test_newMockZookeeperClient(t *testing.T) {
 	testZkAddr(t)
 
@@ -178,74 +219,89 @@ func Test_newMockZookeeperClient(t *testing.T) {
 	verifyEventStateOrder(t, event, states, "event channel")
 }
 
+// TestCreate verifies that Create creates a node along with any missing
+// ancestor nodes.
 func TestCreate(t *testing.T) {
 	testZkAddr(t)
 
 	z, event, err := NewMockZookeeperClient("test", 15*time.Second)
 	assert.NoError(t, err)
 	defer z.Close()
+	defer cleanupZkPath(z, testRootPath)
 
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
 
-	cleanupZkPath(z, "/test1")
-	err = z.Create("/test1/test2/test3/test4")
+	cleanupZkPath(z, testRootPath)
+	err = z.Create(testRootPath + "/test2/test3/test4")
 	assert.NoError(t, err)
 }
 
+// TestCreateDelete verifies that a node created with Create can subsequently
+// be removed with Delete.
 func TestCreateDelete(t *testing.T) {
 	testZkAddr(t)
 
 	z, event, err := NewMockZookeeperClient("test", 15*time.Second)
 	assert.NoError(t, err)
 	defer z.Close()
+	defer cleanupZkPath(z, testRootPath)
 
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
 
-	cleanupZkPath(z, "/test1")
-	err = z.Create("/test1/test2/test3/test4")
+	cleanupZkPath(z, testRootPath)
+	err = z.Create(testRootPath + "/test2/test3/test4")
 	assert.NoError(t, err)
-	err = z.Delete("/test1/test2/test3/test4")
+	err = z.Delete(testRootPath + "/test2/test3/test4")
 	assert.NoError(t, err)
 	// verifyEventOrder(t, event, []zk.EventType{zk.EventNodeCreated}, "event channel")
 }
 
+// TestRegisterTemp verifies that RegisterTemp creates an ephemeral child
+// node at the expected path.
 func TestRegisterTemp(t *testing.T) {
 	testZkAddr(t)
 
 	z, event, err := NewMockZookeeperClient("test", 15*time.Second)
 	assert.NoError(t, err)
 	defer z.Close()
+	defer cleanupZkPath(z, testRootPath)
 
-	cleanupZkPath(z, "/test1")
-	err = z.Create("/test1/test2/test3")
+	cleanupZkPath(z, testRootPath)
+	err = z.Create(testRootPath + "/test2/test3")
 	assert.NoError(t, err)
 
-	tmpath, err := z.RegisterTemp("/test1/test2/test3", "test4")
+	tmpath, err := z.RegisterTemp(testRootPath+"/test2/test3", "test4")
 	assert.NoError(t, err)
-	assert.Equal(t, "/test1/test2/test3/test4", tmpath)
+	assert.Equal(t, testRootPath+"/test2/test3/test4", tmpath)
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
 }
 
+// TestRegisterTempSeq verifies that RegisterTempSeq creates an ephemeral
+// sequential child node, starting at sequence number 0 for a freshly created
+// parent.
 func TestRegisterTempSeq(t *testing.T) {
 	testZkAddr(t)
 
 	z, event, err := NewMockZookeeperClient("test", 15*time.Second)
 	assert.NoError(t, err)
 	defer z.Close()
+	defer cleanupZkPath(z, testRootPath)
 
-	cleanupZkPath(z, "/test1")
-	err = z.Create("/test1/test2/test3")
+	cleanupZkPath(z, testRootPath)
+	err = z.Create(testRootPath + "/test2/test3")
 	assert.NoError(t, err)
-	tmpath, err := z.RegisterTempSeq("/test1/test2/test3", []byte("test"))
+	tmpath, err := z.RegisterTempSeq(testRootPath+"/test2/test3", []byte("test"))
 	assert.NoError(t, err)
-	assert.Equal(t, "/test1/test2/test3/0000000000", tmpath)
+	assert.Equal(t, testRootPath+"/test2/test3/0000000000", tmpath)
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
 }
 
+// Test_UnregisterEvent verifies that UnregisterEvent removes a previously
+// registered event channel without panicking.
 func Test_UnregisterEvent(t *testing.T) {
 	client := &ZookeeperClient{}
 	client.eventRegistry = make(map[string][]chan zk.Event)

--- a/database/kv/zk/options.go
+++ b/database/kv/zk/options.go
@@ -21,15 +21,10 @@ import (
 	"time"
 )
 
-import (
-	"github.com/dubbogo/go-zookeeper/zk"
-)
-
 // nolint
 type options struct {
 	ZkName string
 	Client *ZookeeperClient
-	Ts     *zk.TestCluster
 }
 
 // Option will define a function of handling Options

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/buger/jsonparser v1.1.2
 	github.com/davecgh/go-spew v1.1.1
-	github.com/dubbogo/go-zookeeper v1.0.4-0.20211212162352-f9d2183d89d5
+	github.com/go-zookeeper/zk v1.0.4
 	github.com/k0kubun/pp v3.0.1+incompatible
 	github.com/mattn/go-isatty v0.0.16
 	github.com/nacos-group/nacos-sdk-go/v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/dubbogo/go-zookeeper v1.0.4-0.20211212162352-f9d2183d89d5 h1:XoR8SSVziXe698dt4uZYDfsmHpKLemqAgFyndQsq5Kw=
-github.com/dubbogo/go-zookeeper v1.0.4-0.20211212162352-f9d2183d89d5/go.mod h1:fn6n2CAEer3novYgk9ULLwAjuV8/g4DdC2ENwRb6E+c=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -127,6 +125,8 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-zookeeper/zk v1.0.4 h1:DPzxraQx7OrPyXq2phlGlNSIyWEsAox0RJmjTseMV6I=
+github.com/go-zookeeper/zk v1.0.4/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=


### PR DESCRIPTION
## What

Migrates `database/kv/zk` off the fork `github.com/dubbogo/go-zookeeper` onto upstream `github.com/go-zookeeper/zk v1.0.4`.

This is the prerequisite for apache/dubbo-go#3459 (dubbo-go cannot switch to the upstream zk client until gost's wrapper stops depending on the fork's private API surface).

## Why

- The fork has been unmaintained for ~4 years; upstream `go-zookeeper/zk` is the actively released successor of `samuel/go-zookeeper`.
- gost was the only remaining hard dependency on fork-private APIs: `*zk.Watcher` / `watcher.EvtCh`, `zk.WithRetryTimes`, and the importable `zk.TestCluster` / `zk.StartTestCluster` helpers (upstream keeps those in its own `_test.go` files, so they are not importable as library API).

## Changes

- **`client.go` / `options.go`**: import upstream `github.com/go-zookeeper/zk`. `GetChildrenW` / `ExistW` now consume the `<-chan zk.Event` that upstream `ChildrenW` / `ExistsW` return directly, instead of the fork's `*Watcher.EvtCh`. **Public method signatures are unchanged** — downstream callers of `ZookeeperClient` (including dubbo-go) compile as-is.
- **`WithRetryTimes` dropped** from the `zk.Connect` call — upstream reconnects automatically; there is no equivalent option.
- **`NewMockZookeeperClient`** (breaking, unavoidable): `*zk.TestCluster` no longer exists as an importable type, so the signature changes from 4 return values to 3 (the `*zk.TestCluster` return is removed). Instead of booting an in-process cluster it now dials a real ZooKeeper server (`ZK_ADDR` env var, default `127.0.0.1:2181`), with an explicit TCP reachability probe first to preserve the old fail-fast contract (upstream `zk.Connect` dials in the background and does not fail fast).
- **`WithTestCluster`** option and the `options.Ts` field are removed for the same reason.
- **`client_test.go`**: tests that used `StartTestCluster` now skip cleanly when no ZooKeeper is reachable and run against a real one otherwise; all original assertions are preserved. Added a best-effort recursive cleanup helper so `Create`-based tests are repeatable against a long-lived server.
- **`go.mod` / `go.sum`**: drop `dubbogo/go-zookeeper`, add `github.com/go-zookeeper/zk v1.0.4`, `go mod tidy`.

## Compatibility summary

| API | Status |
|---|---|
| `GetChildrenW`, `ExistW`, `RegisterEvent`, `Create*`, `Delete`, `GetContent`, `SetContent`, `GetChildren`, `ZkConnValid`, `RegisterTemp`, `RegisterTempSeq`, `Reconnect`, `Close`, ... | unchanged |
| `NewMockZookeeperClient` | **breaking**: 3 return values, requires a reachable real ZooKeeper (`ZK_ADDR`) |
| `WithTestCluster`, `options.Ts` | **removed** |

## Verification (all against a real ZooKeeper 3.9.5, no mocks)

- `go build ./...`, `go vet ./database/kv/zk/` — clean.
- `go test ./database/kv/zk/ -count=1` — **8/8 pass** with a live server (skip cleanly without one).
- Watcher re-establishment after disconnect was verified end-to-end together with dubbo-go's listener layer, including the strictest case:
  - **session expiry**: stopped the server for 15s (session timeout 4s), restarted — the client re-established the session in ~0.3s and the watch was re-armed and delivering events within 30ms. Mechanism: on session expiry upstream delivers `EventNotWatching` to all watchers, which unblocks dubbo-go's `listenDirEvent` loop to re-call `GetChildrenW` on the new session.
  - **transient blip (session survives)**: paused the server process (SIGSTOP/SIGCONT, 2s < session timeout) — the server restored watches transparently; events kept flowing with no re-subscribe needed.
- Full register / subscribe / unsubscribe event flow via dubbo-go's `ZkEventListener`: subscribe receives add/delete child events; after `Close()` no further callbacks arrive.

## Notes for reviewers

- `database/kv/zk/zookeeper-3.4.9/contrib/fatjar/*.jar` is now dead weight (its only consumer was the fork's embedded test-cluster helper). Left untouched here to keep the diff focused; can be removed in a follow-up.
- apache/dubbo-go has a companion PR that flips its imports and go.mod in lockstep; it is blocked on this PR being merged and released.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved ZooKeeper connection reliability by confirming session establishment before use.
  * Added clearer errors when a ZooKeeper connection or handshake cannot be completed.
  * Updated ZooKeeper connectivity for more consistent connection handling.

* **Tests**
  * Improved test isolation with randomized namespaces and automatic cleanup.
  * Added checks to ensure ZooKeeper is reachable and ready before tests run.
  * Expanded coverage for connection setup and registration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->