### PR TITLE
fix(etcd): bound keepSession so NewClient respects its timeout again

### DIFF
--- a/database/kv/etcd/v3/client.go
+++ b/database/kv/etcd/v3/client.go
@@ -222,16 +222,52 @@ func (c *Client) Close() {
 	log.Printf("etcd client{Name:%s, Endpoints:%s} exit now.", c.name, c.endpoints)
 }
 
+// keepSession establishes the etcd concurrency Session (granting a lease
+// over RPC) that keepSessionLoop then holds open. Since NewClient no longer
+// dials with grpc.WithBlock() (see the revert in commit 3412137), the raw
+// client it's handed can be returned before it's actually connected, and
+// concurrency.NewSession's own Grant call carries no deadline of its own -
+// against an unreachable server it can block indefinitely. Race it against
+// c.timeout here so callers get back the bounded failure NewClient has
+// always documented, instead of hanging forever regardless of the timeout
+// they asked for.
+//
+// A session that completes after we've already timed out and returned is
+// abandoned rather than awaited: its Grant call shares c.ctx, which the
+// caller cancels on our error return, so it will itself unwind once that
+// happens rather than leak.
 func (c *Client) keepSession() error {
-	s, err := concurrency.NewSession(c.rawClient, concurrency.WithTTL(c.heartbeat))
-	if err != nil {
-		return perrors.WithMessage(err, "new session with server")
+	type sessionResult struct {
+		s   *concurrency.Session
+		err error
+	}
+	resCh := make(chan sessionResult, 1)
+	go func() {
+		s, err := concurrency.NewSession(c.rawClient, concurrency.WithTTL(c.heartbeat))
+		resCh <- sessionResult{s, err}
+	}()
+
+	// A timeout <= 0 has always meant "no bound, block until connected or
+	// cancelled" (it's passed straight through as grpc's DialTimeout too),
+	// so preserve that instead of racing against a channel that would fire
+	// immediately.
+	var deadline <-chan time.Time
+	if c.timeout > 0 {
+		deadline = time.After(c.timeout)
 	}
 
-	// must add wg before go keep session goroutine
-	c.Wait.Add(1)
-	go c.keepSessionLoop(s)
-	return nil
+	select {
+	case res := <-resCh:
+		if res.err != nil {
+			return perrors.WithMessage(res.err, "new session with server")
+		}
+		// must add wg before go keep session goroutine
+		c.Wait.Add(1)
+		go c.keepSessionLoop(res.s)
+		return nil
+	case <-deadline:
+		return perrors.Errorf("new session with server: timed out after %s", c.timeout)
+	}
 }
 
 func (c *Client) keepSessionLoop(s *concurrency.Session) {


### PR DESCRIPTION
## What

`NewClient`/`NewClientWithOptions` in `database/kv/etcd/v3` can hang indefinitely against an unreachable etcd server, regardless of the `timeout` passed to them.

## Why

#141 removed `grpc.WithBlock()` from the dial so `NewClient` returns without waiting for a live connection. That's fine on its own, but `keepSession()`'s call to `concurrency.NewSession` (which grants a lease over RPC to establish the session) is made synchronously right after, with no deadline of its own. Against an unreachable server that RPC now blocks forever, so `NewClient` never returns - a real regression from the timeout contract the function has always documented, not just a slower dial.

I found this while migrating `dubbogo-go`'s `#3459` zk work: bumping its `gost` dependency past this commit made two of its etcd tests hang for the full 10-minute `go test` timeout and fail CI, where they previously passed in milliseconds. Reproduced directly against gost too:

```
$ go run . # NewClient("test", []string{"127.0.0.1:19999"}, 3*time.Second, 1)
before: never returns
after:  elapsed=3.002641875s err=client keep session: new session with server: timed out after 3s
```

## Fix

Race `concurrency.NewSession` against `c.timeout` inside `keepSession`, returning the bounded error `NewClient` already promised instead of hanging. `timeout <= 0` keeps meaning "no bound" (matching how it's already used as grpc's `DialTimeout`), so it doesn't change behavior for callers relying on that. A session that completes after the timeout has already fired is left to unwind on its own - its `Grant` call shares the client's `ctx`, which `NewClient` cancels on our error return, so it isn't a leak.

## Test plan

- [x] `go test ./database/kv/etcd/v3/...` - all 10 cases in the existing embedded-etcd suite pass, including `TestClientRegisterTemp` (32s, long-running lease/keepalive), confirming the fix doesn't shorten a session that did establish successfully.
- [x] Manual repro against an address with nothing listening: fails after exactly the configured timeout instead of hanging (see above).
- [x] `go build ./...`, `go vet ./...` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session startup responsiveness by enforcing the configured timeout.
  - Returns a timeout error when session creation takes too long.
  - Preserves unlimited waiting when no positive timeout is configured.
  - Ensures session maintenance begins only after successful session creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Fixes #148.
